### PR TITLE
Catch error when statusupdate is failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,8 +362,13 @@ eWeLink.prototype.addAccessory = function(device, deviceId = null) {
         channel = id[1];
     }
 
-    const status = channel && device.params.switches && device.params.switches[channel-1] ? device.params.switches[channel-1].switch : device.params.switch || "off";
-    this.log("Found Accessory with Name : [%s], Manufacturer : [%s], Status : [%s], Is Online : [%s], API Key: [%s] ", device.name + (channel ? ' CH ' + channel : ''), device.productModel, status, device.online, device.apikey);
+    try {   
+        const status = channel && device.params.switches && device.params.switches[channel-1] ? device.params.switches[channel-1].switch : device.params.switch || "off";
+        this.log("Found Accessory with Name : [%s], Manufacturer : [%s], Status : [%s], Is Online : [%s], API Key: [%s] ", device.name + (channel ? ' CH ' + channel : ''), device.productModel, status, device.online, device.apikey);
+    } catch (e) {
+        this.log("Problem accessory Accessory with Name : [%s], Manufacturer : [%s], Error : [%s], Is Online : [%s], API Key: [%s] ", device.name + (channel ? ' CH ' + channel : ''), device.productModel, e, device.online, device.apikey);
+    }
+
     const accessory = new Accessory(device.name + (channel ? ' CH ' + channel : ''), UUIDGen.generate((deviceId ? deviceId : device.deviceid).toString()));
 
     accessory.context.deviceId = deviceId ? deviceId : device.deviceid;


### PR DESCRIPTION
When an error occurs at getting the status like

mebridge/node_modules/homebridge-ewelink-max/index.js:365
    const status = channel && device.params.switches && device.params.switches[channel-1] ? device.params.switches[channel-1].switch : device.params.switch || "off";
                                                                                                                                                     ^
TypeError: Cannot read property 'switch' of undefined

I updated to catch the error otherwise complete homebridge setup fails to run